### PR TITLE
add simple HTML parser for web URL script loading

### DIFF
--- a/src/foundation/html_parser.c
+++ b/src/foundation/html_parser.c
@@ -1,0 +1,186 @@
+#include "foundation/html_parser.h"
+#include "foundation/logger.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+// ---- helpers ----------------------------------------------------------------
+
+static int str_iequal_n(const char *a, const char *b, u32 n) {
+    for (u32 i = 0; i < n; i++) {
+        if (tolower((unsigned char)a[i]) != tolower((unsigned char)b[i]))
+            return 0;
+    }
+    return 1;
+}
+
+// Case-insensitive search of `needle` (length nlen) inside [haystack, end).
+// Returns pointer to first match or NULL.
+static const char *mem_istr(const char *haystack, const char *end, const char *needle, u32 nlen) {
+    if (nlen == 0 || haystack + nlen > end)
+        return NULL;
+    for (const char *p = haystack; p + nlen <= end; p++) {
+        if (str_iequal_n(p, needle, nlen))
+            return p;
+    }
+    return NULL;
+}
+
+// ---- public API -------------------------------------------------------------
+
+bool html_is_html(const char *data, u32 length) {
+    if (length < 5)
+        return false;
+    // Skip optional BOM / whitespace
+    u32 skip = 0;
+    while (skip < length && (data[skip] == ' ' || data[skip] == '\r' || data[skip] == '\n' || data[skip] == '\t'))
+        skip++;
+    const char *d = data + skip;
+    u32 rem = length - skip;
+    if (rem >= 9 && str_iequal_n(d, "<!doctype", 9))
+        return true;
+    if (rem >= 6 && str_iequal_n(d, "<html", 5))
+        return true;
+    // Fallback: scan first 512 bytes for <html tag
+    u32 scan = rem < 512 ? rem : 512;
+    if (mem_istr(d, d + scan, "<html", 5) != NULL)
+        return true;
+    return false;
+}
+
+ustring html_resolve_url(url_t base, const char *src, u32 src_len) {
+    // Absolute URL
+    if (src_len >= 7 && (str_iequal_n(src, "http://", 7) || str_iequal_n(src, "https:/", 7))) {
+        char *buf = (char *)malloc(src_len + 1);
+        memcpy(buf, src, src_len);
+        buf[src_len] = '\0';
+        return (ustring){.data = buf, .length = src_len, .null_terminated = true, .is_static = false};
+    }
+
+    // Build base prefix: "http://host:port"
+    ustring_view host = base.url;  // full original URL available through url.url
+    // Reconstruct origin from parts
+    const char *proto_data = base.protocol.base.data + base.protocol.start;
+    u32 proto_len = base.protocol.length;
+    const char *host_data = base.host.base.data + base.host.start;
+    u32 host_len = base.host.length;
+    const char *path_data = base.path.base.data + base.path.start;
+    u32 path_len = base.path.length;
+
+    char port_str[8] = {0};
+    u32 port_len = 0;
+    if (base.port != 80 && base.port != 443) {
+        port_len = (u32)snprintf(port_str, sizeof(port_str), ":%d", base.port);
+    }
+
+    // Protocol-relative: //host/path
+    if (src_len >= 2 && src[0] == '/' && src[1] == '/') {
+        u32 total = proto_len + 1 + src_len + 1; // proto + ":" + src + NUL
+        char *buf = (char *)malloc(total);
+        u32 off = 0;
+        memcpy(buf + off, proto_data, proto_len); off += proto_len;
+        buf[off++] = ':';
+        memcpy(buf + off, src, src_len); off += src_len;
+        buf[off] = '\0';
+        return (ustring){.data = buf, .length = off, .null_terminated = true, .is_static = false};
+    }
+
+    // Root-relative: /path
+    if (src_len >= 1 && src[0] == '/') {
+        u32 total = proto_len + 3 + host_len + port_len + src_len + 1;
+        char *buf = (char *)malloc(total);
+        u32 off = 0;
+        memcpy(buf + off, proto_data, proto_len); off += proto_len;
+        buf[off++] = ':'; buf[off++] = '/'; buf[off++] = '/';
+        memcpy(buf + off, host_data, host_len); off += host_len;
+        if (port_len) { memcpy(buf + off, port_str, port_len); off += port_len; }
+        memcpy(buf + off, src, src_len); off += src_len;
+        buf[off] = '\0';
+        return (ustring){.data = buf, .length = off, .null_terminated = true, .is_static = false};
+    }
+
+    // Relative: resolve against directory of base path
+    // Find last '/' in base path
+    u32 dir_len = 0;
+    for (u32 i = 0; i < path_len; i++) {
+        if (path_data[i] == '/')
+            dir_len = i + 1;
+    }
+
+    u32 total = proto_len + 3 + host_len + port_len + dir_len + src_len + 1;
+    char *buf = (char *)malloc(total);
+    u32 off = 0;
+    memcpy(buf + off, proto_data, proto_len); off += proto_len;
+    buf[off++] = ':'; buf[off++] = '/'; buf[off++] = '/';
+    memcpy(buf + off, host_data, host_len); off += host_len;
+    if (port_len) { memcpy(buf + off, port_str, port_len); off += port_len; }
+    memcpy(buf + off, path_data, dir_len); off += dir_len;
+    memcpy(buf + off, src, src_len); off += src_len;
+    buf[off] = '\0';
+    return (ustring){.data = buf, .length = off, .null_terminated = true, .is_static = false};
+}
+
+html_parse_result_t html_parse_scripts(const char *data, u32 length, url_t base_url) {
+    html_parse_result_t result = {0};
+    const char *end = data + length;
+    const char *p = data;
+
+    while (result.count < HTML_MAX_SCRIPTS) {
+        // Find next <script
+        const char *tag_start = mem_istr(p, end, "<script", 7);
+        if (!tag_start)
+            break;
+
+        // Find end of opening tag
+        const char *tag_end = tag_start + 7;
+        while (tag_end < end && *tag_end != '>')
+            tag_end++;
+        if (tag_end >= end)
+            break;
+
+        // Check for src= attribute within opening tag
+        const char *src_attr = mem_istr(tag_start + 7, tag_end, "src=", 4);
+
+        if (src_attr) {
+            src_attr += 4; // skip "src="
+            char quote = (src_attr < tag_end) ? *src_attr : 0;
+            if (quote == '"' || quote == '\'') {
+                src_attr++; // skip quote
+                const char *src_end = src_attr;
+                while (src_end < tag_end && *src_end != quote)
+                    src_end++;
+                u32 src_len = (u32)(src_end - src_attr);
+                if (src_len > 0) {
+                    ustring resolved = html_resolve_url(base_url, src_attr, src_len);
+                    result.scripts[result.count].src = resolved;
+                    result.scripts[result.count].code = ustring_NULL;
+                    result.count++;
+                    ULOG_INFO_FMT("html_parser: found script src: {}", resolved.data);
+                }
+            }
+        } else {
+            // Inline script: extract content between > and </script>
+            const char *body_start = tag_end + 1;
+            const char *close_tag = mem_istr(body_start, end, "</script>", 9);
+            if (!close_tag)
+                close_tag = end;
+            u32 code_len = (u32)(close_tag - body_start);
+            if (code_len > 0) {
+                char *buf = (char *)malloc(code_len + 1);
+                memcpy(buf, body_start, code_len);
+                buf[code_len] = '\0';
+                result.scripts[result.count].src = ustring_NULL;
+                result.scripts[result.count].code = (ustring){.data = buf, .length = code_len, .null_terminated = true, .is_static = false};
+                result.count++;
+                ULOG_INFO_FMT("html_parser: found inline script ({d} bytes)", code_len);
+            }
+            p = close_tag + 9;
+            continue;
+        }
+
+        p = tag_end + 1;
+    }
+
+    return result;
+}

--- a/src/foundation/html_parser.h
+++ b/src/foundation/html_parser.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "foundation/global.h"
+#include "foundation/ustring.h"
+#include "foundation/network.h"
+
+#define HTML_MAX_SCRIPTS 32
+
+// A parsed <script> entry: either external (src set) or inline (code set).
+// src is a heap-allocated null-terminated ustring — caller must ustring_free it.
+// code points into the original content buffer — no allocation.
+typedef struct html_script_t {
+    ustring src;   // external: resolved absolute URL; empty if inline
+    ustring code;  // inline: script text; empty if external
+} html_script_t;
+
+typedef struct html_parse_result_t {
+    html_script_t scripts[HTML_MAX_SCRIPTS];
+    u32 count;
+} html_parse_result_t;
+
+// Returns true if the content looks like an HTML document.
+bool html_is_html(const char *data, u32 length);
+
+// Parse all <script> tags from HTML content.
+html_parse_result_t html_parse_scripts(const char *data, u32 length, url_t base_url);
+
+// Resolve a (possibly relative) src against the base URL into a new heap string.
+// Caller must ustring_free the result.
+ustring html_resolve_url(url_t base, const char *src, u32 src_len);

--- a/src/foundation/network.c
+++ b/src/foundation/network.c
@@ -10,6 +10,8 @@ typedef struct net_session_t {
     net_request_t request;
     net_response_t response;
     url_session_cb cb;
+    void *userdata;
+    ustring url_buf; // owned copy of URL string — ensures url_t views stay valid
 } net_session_t;
 
 url_t url_parse(ustring_view url) {
@@ -154,7 +156,9 @@ static void on_alloc(uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf) 
 }
 
 static void on_close(uv_handle_t *handle) {
-    free(handle);
+    net_session_t *session = (net_session_t *)handle;
+    ustring_free(&session->url_buf);
+    free(session);
     ULOG_INFO("closed.\n");
 }
 
@@ -214,7 +218,7 @@ static void on_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
         if (nread != UV_EOF) {
             ULOG_ERROR_FMT("read error {}", uv_err_name((int)nread));
         }
-        session->cb(session->request, session->response);
+        session->cb(session->request, session->response, session->userdata);
         uv_close((uv_handle_t *)stream, on_close);
     } else if (nread > 0) {
         if (!session->response.header_parsed) {
@@ -226,7 +230,7 @@ static void on_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
 
         if (body_read_end(&session->response)) {
             parse_response(&session->response);
-            session->cb(session->request, session->response);
+            session->cb(session->request, session->response, session->userdata);
             uv_read_stop(stream);
             uv_close((uv_handle_t *)stream, on_close);
             udata_free(&session->response.data);
@@ -236,9 +240,17 @@ static void on_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
     free(buf->base);
 }
 
+static void on_read_error(uv_stream_t *stream, net_session_t *session) {
+    session->cb(session->request, session->response, session->userdata);
+    uv_close((uv_handle_t *)stream, on_close);
+}
+
 static void on_connect(uv_connect_t *conn, int status) {
     if (status < 0) {
         ULOG_ERROR_FMT("connection error {}", uv_err_name(status));
+        net_session_t *session = conn->data;
+        on_read_error(conn->handle, session);
+        free(conn);
         return;
     }
 
@@ -253,23 +265,31 @@ static void on_connect(uv_connect_t *conn, int status) {
     uv_buf_t buf = uv_buf_init((char *)body.base.data, body.base.length);
     uv_write(write_req, stream, &buf, 1, on_write);
     uv_read_start(stream, on_alloc, on_read);
+    free(conn);
 }
 
-int net_download_async(url_t url, url_session_cb cb) {
-    uv_getaddrinfo_t resolver;
-    ustring host = ustring_view_to_new_ustring(&url.host);
+int net_download_async(url_t url, url_session_cb cb, void *userdata) {
+    // Copy the URL string so views in url_t remain valid for the lifetime of the request.
+    ustring url_copy = ustring_view_to_new_ustring(&url.url);
+    ustring_view url_view = ustring_view_from_ustring(url_copy);
+    url_t url_owned = url_parse(url_view);
+
+    ustring host = ustring_view_to_new_ustring(&url_owned.host);
 
     struct sockaddr_in addr;
-    uv_ip4_addr(host.data, url.port, &addr);
+    uv_ip4_addr(host.data, url_owned.port, &addr);
+    ustring_free(&host);
 
     net_session_t *session = malloc(sizeof(net_session_t));
     session->response.data = (udata){.data = NULL, .length = 0};
     session->response.error = ustring_view_STR("");
     session->response.header_parsed = false;
     session->cb = cb;
+    session->userdata = userdata;
+    session->url_buf = url_copy;
 
     uv_tcp_init(uv_default_loop(), &session->request.socket);
-    session->request.url = url;
+    session->request.url = url_owned;
 
     uv_connect_t *connect = malloc(sizeof(uv_connect_t));
     connect->data = session;

--- a/src/foundation/network.h
+++ b/src/foundation/network.h
@@ -33,5 +33,5 @@ typedef struct net_response_t {
 url_t url_parse(ustring_view url);
 void url_dump(url_t url);
 
-typedef void(*url_session_cb)(net_request_t request, net_response_t response);
-int net_download_async(url_t url, url_session_cb cb);
+typedef void(*url_session_cb)(net_request_t request, net_response_t response, void *userdata);
+int net_download_async(url_t url, url_session_cb cb, void *userdata);

--- a/src/script/script.qjs.c
+++ b/src/script/script.qjs.c
@@ -5,6 +5,7 @@
 #include "foundation/global.h"
 #include "foundation/ustring.h"
 #include "foundation/network.h"
+#include "foundation/html_parser.h"
 #include "foundation/logger.h"
 #include "foundation/io.h"
 #include "ui/ui_dev_tool.h"
@@ -208,13 +209,45 @@ int script_eval_direct(ustring source, ustring *result) {
     return ret;
 }
 
+static void on_html_script_download(net_request_t request, net_response_t response) {
+    ULOG_INFO_FMT("status: {d}", response.status);
+    ustring source = ustring_view_to_ustring(&response.body);
+    shared_context.invalid_script = script_eval(source, request.url.url) != 0;
+
+    os_window_t *window = shared_context.window;
+    os_window_on_resize(window, window->width, window->height);
+}
+
 static void on_remote_script_download(net_request_t request, net_response_t response) {
-    // ULOG_INFO_FMT("remote script downloaded: {v}", request.url);
     ULOG_INFO_FMT("status: {d}", response.status);
     ULOG_INFO_FMT("content_length: {d}", response.content_length);
     ULOG_INFO_FMT("header_length: {d}", response.header_length);
-    shared_context.invalid_script = script_eval(ustring_view_to_ustring(&response.body), request.url.url) != 0;
-    script_t *ctx = script_shared();
+
+    const char *body_data = response.body.base.data + response.body.start;
+    u32 body_len = response.body.length;
+
+    if (html_is_html(body_data, body_len)) {
+        ULOG_INFO("html_parser: detected HTML page, extracting scripts");
+        html_parse_result_t parsed = html_parse_scripts(body_data, body_len, request.url);
+        for (u32 i = 0; i < parsed.count; i++) {
+            html_script_t *s = &parsed.scripts[i];
+            if (s->src.length > 0) {
+                ustring_view src_view = ustring_view_from_ustring(s->src);
+                url_t script_url = url_parse(src_view);
+                if (script_url.valid) {
+                    ULOG_INFO_FMT("html_parser: loading script: {}", s->src.data);
+                    net_download_async(script_url, on_html_script_download);
+                }
+                ustring_free(&s->src);
+            } else if (s->code.length > 0) {
+                ustring_view filename = ustring_view_STR("<inline>");
+                shared_context.invalid_script = script_eval(s->code, filename) != 0;
+                ustring_free(&s->code);
+            }
+        }
+    } else {
+        shared_context.invalid_script = script_eval(ustring_view_to_ustring(&response.body), request.url.url) != 0;
+    }
 
     os_window_t *window = shared_context.window;
     os_window_on_resize(window, window->width, window->height);

--- a/src/script/script.qjs.c
+++ b/src/script/script.qjs.c
@@ -143,6 +143,7 @@ void script_setup(void) {
     JSContext *ctx = shared_module.context;
     JSValue global = JS_GetGlobalObject(ctx);
     JS_SetPropertyFunctionList(ctx, global, js_console_funcs, count_of(js_console_funcs));
+    JS_SetPropertyStr(ctx, global, "fetch", JS_NewCFunction(ctx, js_fetch, "fetch", 1));
     JS_FreeValue(ctx, global);
 
     script_gpu_setup();
@@ -209,7 +210,142 @@ int script_eval_direct(ustring source, ustring *result) {
     return ret;
 }
 
-static void on_html_script_download(net_request_t request, net_response_t response) {
+// ---------------------------------------------------------------------------
+// fetch() — returns Promise<Response>; Response has .arrayBuffer()/.text()/.json()
+// ---------------------------------------------------------------------------
+
+typedef struct qjs_fetch_ctx_t {
+    JSContext *ctx;
+    JSValue resolve;
+    JSValue reject;
+} qjs_fetch_ctx_t;
+
+static JSValue js_response_array_buffer(JSContext *ctx, JSValueConst this_val,
+                                         int argc, JSValueConst *argv,
+                                         int magic, JSValue *func_data) {
+    JSValue ab = JS_DupValue(ctx, func_data[0]);
+    JSValue resolving_funcs[2];
+    JSValue promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+    JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, &ab);
+    JS_FreeValue(ctx, resolving_funcs[0]);
+    JS_FreeValue(ctx, resolving_funcs[1]);
+    JS_FreeValue(ctx, ab);
+    return promise;
+}
+
+static JSValue js_response_text(JSContext *ctx, JSValueConst this_val,
+                                 int argc, JSValueConst *argv,
+                                 int magic, JSValue *func_data) {
+    size_t byte_len;
+    JS_GetArrayBuffer(ctx, &byte_len, func_data[0]);
+    uint8_t *buf = JS_GetArrayBuffer(ctx, &byte_len, func_data[0]);
+    JSValue text = JS_NewStringLen(ctx, (const char *)buf, byte_len);
+    JSValue resolving_funcs[2];
+    JSValue promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+    JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, &text);
+    JS_FreeValue(ctx, resolving_funcs[0]);
+    JS_FreeValue(ctx, resolving_funcs[1]);
+    JS_FreeValue(ctx, text);
+    return promise;
+}
+
+static JSValue js_response_json(JSContext *ctx, JSValueConst this_val,
+                                 int argc, JSValueConst *argv,
+                                 int magic, JSValue *func_data) {
+    size_t byte_len;
+    uint8_t *buf = JS_GetArrayBuffer(ctx, &byte_len, func_data[0]);
+    JSValue json = JS_ParseJSON(ctx, (const char *)buf, byte_len, "<fetch>");
+    JSValue resolving_funcs[2];
+    JSValue promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+    JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, &json);
+    JS_FreeValue(ctx, resolving_funcs[0]);
+    JS_FreeValue(ctx, resolving_funcs[1]);
+    JS_FreeValue(ctx, json);
+    return promise;
+}
+
+static void on_qjs_fetch_done(net_request_t request, net_response_t response, void *userdata) {
+    qjs_fetch_ctx_t *fc = (qjs_fetch_ctx_t *)userdata;
+    JSContext *ctx = fc->ctx;
+
+    if (response.status == 0) {
+        JSValue err = JS_NewString(ctx, "network error");
+        JS_Call(ctx, fc->reject, JS_UNDEFINED, 1, &err);
+        JS_FreeValue(ctx, err);
+    } else {
+        const char *body = response.body.base.data + response.body.start;
+        u32 body_len = response.body.length;
+
+        JSValue ab = JS_NewArrayBufferCopy(ctx, (const uint8_t *)body, body_len);
+
+        JSValue resp = JS_NewObject(ctx);
+        JS_SetPropertyStr(ctx, resp, "status", JS_NewInt32(ctx, (i32)response.status));
+        JS_SetPropertyStr(ctx, resp, "ok",
+            JS_NewBool(ctx, response.status >= 200 && response.status < 300));
+        JS_SetPropertyStr(ctx, resp, "arrayBuffer",
+            JS_NewCFunctionData(ctx, js_response_array_buffer, 0, 0, 1, &ab));
+        JS_SetPropertyStr(ctx, resp, "text",
+            JS_NewCFunctionData(ctx, js_response_text, 0, 0, 1, &ab));
+        JS_SetPropertyStr(ctx, resp, "json",
+            JS_NewCFunctionData(ctx, js_response_json, 0, 0, 1, &ab));
+        JS_FreeValue(ctx, ab);
+
+        JS_Call(ctx, fc->resolve, JS_UNDEFINED, 1, &resp);
+        JS_FreeValue(ctx, resp);
+    }
+
+    JS_FreeValue(ctx, fc->resolve);
+    JS_FreeValue(ctx, fc->reject);
+    free(fc);
+}
+
+static JSValue js_fetch(JSContext *ctx, JSValueConst _, int argc, JSValueConst *argv) {
+    JSValue resolving_funcs[2];
+    JSValue promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+
+    if (argc < 1 || !JS_IsString(argv[0])) {
+        JSValue err = JS_NewString(ctx, "fetch: expected URL string");
+        JS_Call(ctx, resolving_funcs[1], JS_UNDEFINED, 1, &err);
+        JS_FreeValue(ctx, err);
+        JS_FreeValue(ctx, resolving_funcs[0]);
+        JS_FreeValue(ctx, resolving_funcs[1]);
+        return promise;
+    }
+
+    const char *url_str = JS_ToCString(ctx, argv[0]);
+    ustring url_ustring = ustring_str(url_str);
+    ustring_view url_view = ustring_view_from_ustring(url_ustring);
+    url_t url = url_parse(url_view);
+
+    if (!url.valid) {
+        JSValue err = JS_NewString(ctx, "fetch: invalid URL");
+        JS_Call(ctx, resolving_funcs[1], JS_UNDEFINED, 1, &err);
+        JS_FreeValue(ctx, err);
+        JS_FreeCString(ctx, url_str);
+        JS_FreeValue(ctx, resolving_funcs[0]);
+        JS_FreeValue(ctx, resolving_funcs[1]);
+        return promise;
+    }
+
+    qjs_fetch_ctx_t *fc = malloc(sizeof(qjs_fetch_ctx_t));
+    fc->ctx = ctx;
+    fc->resolve = JS_DupValue(ctx, resolving_funcs[0]);
+    fc->reject  = JS_DupValue(ctx, resolving_funcs[1]);
+
+    // net_download_async copies the URL string internally, safe to free url_str after.
+    net_download_async(url, on_qjs_fetch_done, fc);
+    JS_FreeCString(ctx, url_str);
+
+    JS_FreeValue(ctx, resolving_funcs[0]);
+    JS_FreeValue(ctx, resolving_funcs[1]);
+    return promise;
+}
+
+// ---------------------------------------------------------------------------
+// HTML / script download callbacks
+// ---------------------------------------------------------------------------
+
+static void on_html_script_download(net_request_t request, net_response_t response, void *userdata) {
     ULOG_INFO_FMT("status: {d}", response.status);
     ustring source = ustring_view_to_ustring(&response.body);
     shared_context.invalid_script = script_eval(source, request.url.url) != 0;
@@ -218,7 +354,7 @@ static void on_html_script_download(net_request_t request, net_response_t respon
     os_window_on_resize(window, window->width, window->height);
 }
 
-static void on_remote_script_download(net_request_t request, net_response_t response) {
+static void on_remote_script_download(net_request_t request, net_response_t response, void *userdata) {
     ULOG_INFO_FMT("status: {d}", response.status);
     ULOG_INFO_FMT("content_length: {d}", response.content_length);
     ULOG_INFO_FMT("header_length: {d}", response.header_length);
@@ -236,7 +372,8 @@ static void on_remote_script_download(net_request_t request, net_response_t resp
                 url_t script_url = url_parse(src_view);
                 if (script_url.valid) {
                     ULOG_INFO_FMT("html_parser: loading script: {}", s->src.data);
-                    net_download_async(script_url, on_html_script_download);
+                    // net_download_async copies the URL, safe to free s->src after.
+                    net_download_async(script_url, on_html_script_download, NULL);
                 }
                 ustring_free(&s->src);
             } else if (s->code.length > 0) {
@@ -262,7 +399,7 @@ int script_eval_uri(ustring_view uri) {
         }
         ULOG_INFO_FMT("download remote script: {v}", uri);
         url_dump(url);
-        net_download_async(url, on_remote_script_download);
+        net_download_async(url, on_remote_script_download, NULL);
     } else {
         ustring content = io_read_file(os_get_bundle_path(ustring_view_to_ustring(&uri)));
         if (content.length == 0) {

--- a/src/script/script.v8.cpp
+++ b/src/script/script.v8.cpp
@@ -125,6 +125,143 @@ static void v8_bind_console(Isolate *iso, Local<Context> ctx) {
 }
 
 // ---------------------------------------------------------------------------
+// fetch() — returns Promise<Response>; Response has .arrayBuffer()/.text()/.json()
+// ---------------------------------------------------------------------------
+
+struct V8FetchCtx {
+    Global<Promise::Resolver> resolver;
+    Global<Context>           js_ctx;
+};
+
+static void cb_response_array_buffer(const FunctionCallbackInfo<Value> &args) {
+    Isolate *iso = args.GetIsolate();
+    Local<Context> ctx = iso->GetCurrentContext();
+    Local<Object> self = args.This();
+    Local<Value> body = self->Get(ctx,
+        String::NewFromUtf8(iso, "_body").ToLocalChecked()).ToLocalChecked();
+    Local<Promise::Resolver> resolver = Promise::Resolver::New(ctx).ToLocalChecked();
+    resolver->Resolve(ctx, body).Check();
+    args.GetReturnValue().Set(resolver->GetPromise());
+}
+
+static void cb_response_text(const FunctionCallbackInfo<Value> &args) {
+    Isolate *iso = args.GetIsolate();
+    Local<Context> ctx = iso->GetCurrentContext();
+    Local<Object> self = args.This();
+    Local<Value> body_val = self->Get(ctx,
+        String::NewFromUtf8(iso, "_body").ToLocalChecked()).ToLocalChecked();
+    Local<ArrayBuffer> ab = Local<ArrayBuffer>::Cast(body_val);
+    auto store = ab->GetBackingStore();
+    Local<String> text = String::NewFromUtf8(iso,
+        (const char *)store->Data(), NewStringType::kNormal,
+        (int)store->ByteLength()).ToLocalChecked();
+    Local<Promise::Resolver> resolver = Promise::Resolver::New(ctx).ToLocalChecked();
+    resolver->Resolve(ctx, text).Check();
+    args.GetReturnValue().Set(resolver->GetPromise());
+}
+
+static void cb_response_json(const FunctionCallbackInfo<Value> &args) {
+    Isolate *iso = args.GetIsolate();
+    Local<Context> ctx = iso->GetCurrentContext();
+    Local<Object> self = args.This();
+    Local<Value> body_val = self->Get(ctx,
+        String::NewFromUtf8(iso, "_body").ToLocalChecked()).ToLocalChecked();
+    Local<ArrayBuffer> ab = Local<ArrayBuffer>::Cast(body_val);
+    auto store = ab->GetBackingStore();
+    Local<String> text = String::NewFromUtf8(iso,
+        (const char *)store->Data(), NewStringType::kNormal,
+        (int)store->ByteLength()).ToLocalChecked();
+    Local<Value> json;
+    if (JSON::Parse(ctx, text).ToLocal(&json)) {
+        Local<Promise::Resolver> resolver = Promise::Resolver::New(ctx).ToLocalChecked();
+        resolver->Resolve(ctx, json).Check();
+        args.GetReturnValue().Set(resolver->GetPromise());
+    }
+}
+
+static void on_v8_fetch_done(net_request_t request, net_response_t response, void *userdata) {
+    V8FetchCtx *fc = (V8FetchCtx *)userdata;
+    Isolate *iso = g_mod.isolate;
+    Isolate::Scope iso_scope(iso);
+    HandleScope scope(iso);
+    Local<Context> ctx = fc->js_ctx.Get(iso);
+    Context::Scope ctx_scope(ctx);
+    Local<Promise::Resolver> resolver = fc->resolver.Get(iso);
+
+    if (response.status == 0) {
+        Local<String> err = String::NewFromUtf8(iso, "network error").ToLocalChecked();
+        resolver->Reject(ctx, err).Check();
+    } else {
+        const char *body = response.body.base.data + response.body.start;
+        u32 body_len = response.body.length;
+
+        Local<ArrayBuffer> ab = ArrayBuffer::New(iso, body_len);
+        memcpy(ab->GetBackingStore()->Data(), body, body_len);
+
+        Local<Object> resp = Object::New(iso);
+        resp->Set(ctx, String::NewFromUtf8(iso, "status").ToLocalChecked(),
+                  Integer::New(iso, response.status)).Check();
+        resp->Set(ctx, String::NewFromUtf8(iso, "ok").ToLocalChecked(),
+                  Boolean::New(iso, response.status >= 200 && response.status < 300)).Check();
+        resp->Set(ctx, String::NewFromUtf8(iso, "_body").ToLocalChecked(), ab).Check();
+
+        auto add_method = [&](const char *name, FunctionCallback cb) {
+            Local<Function> fn = Function::New(ctx, cb).ToLocalChecked();
+            resp->Set(ctx, String::NewFromUtf8(iso, name).ToLocalChecked(), fn).Check();
+        };
+        add_method("arrayBuffer", cb_response_array_buffer);
+        add_method("text",        cb_response_text);
+        add_method("json",        cb_response_json);
+
+        resolver->Resolve(ctx, resp).Check();
+    }
+
+    fc->resolver.Reset();
+    fc->js_ctx.Reset();
+    delete fc;
+}
+
+static void cb_fetch(const FunctionCallbackInfo<Value> &args) {
+    Isolate *iso = args.GetIsolate();
+    Local<Context> ctx = iso->GetCurrentContext();
+
+    Local<Promise::Resolver> resolver = Promise::Resolver::New(ctx).ToLocalChecked();
+
+    if (args.Length() < 1 || !args[0]->IsString()) {
+        Local<String> err = String::NewFromUtf8(iso, "fetch: expected URL string").ToLocalChecked();
+        resolver->Reject(ctx, err).Check();
+        args.GetReturnValue().Set(resolver->GetPromise());
+        return;
+    }
+
+    String::Utf8Value url_utf8(iso, args[0]);
+    ustring url_ustr = ustring_str(*url_utf8);
+    ustring_view url_view = ustring_view_from_ustring(url_ustr);
+    url_t url = url_parse(url_view);
+
+    if (!url.valid) {
+        Local<String> err = String::NewFromUtf8(iso, "fetch: invalid URL").ToLocalChecked();
+        resolver->Reject(ctx, err).Check();
+        args.GetReturnValue().Set(resolver->GetPromise());
+        return;
+    }
+
+    V8FetchCtx *fc = new V8FetchCtx;
+    fc->resolver.Reset(iso, resolver);
+    fc->js_ctx.Reset(iso, ctx);
+
+    // net_download_async copies the URL string internally.
+    net_download_async(url, on_v8_fetch_done, fc);
+    args.GetReturnValue().Set(resolver->GetPromise());
+}
+
+static void v8_bind_fetch(Isolate *iso, Local<Context> ctx) {
+    Local<Function> fn = Function::New(ctx, cb_fetch).ToLocalChecked();
+    ctx->Global()->Set(ctx,
+        String::NewFromUtf8(iso, "fetch").ToLocalChecked(), fn).Check();
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -200,6 +337,7 @@ void script_setup(void) {
 
     Context::Scope ctx_scope(ctx);
     v8_bind_console(iso, ctx);
+    v8_bind_fetch(iso, ctx);
     script_gpu_setup();
 }
 
@@ -280,7 +418,7 @@ int script_eval_direct(ustring source, ustring *result) {
     return 0;
 }
 
-static void on_html_script_download(net_request_t request, net_response_t response) {
+static void on_html_script_download(net_request_t request, net_response_t response, void *userdata) {
     LOG_INFO("script.v8", "html script downloaded");
     g_ctx.invalid_script =
         script_eval(ustring_view_to_ustring(&response.body), request.url.url) != 0;
@@ -289,7 +427,7 @@ static void on_html_script_download(net_request_t request, net_response_t respon
     os_window_on_resize(window, window->width, window->height);
 }
 
-static void on_remote_script_download(net_request_t request, net_response_t response) {
+static void on_remote_script_download(net_request_t request, net_response_t response, void *userdata) {
     LOG_INFO("script.v8", "remote content downloaded");
 
     const char *body_data = response.body.base.data + response.body.start;
@@ -304,7 +442,7 @@ static void on_remote_script_download(net_request_t request, net_response_t resp
                 ustring_view src_view = ustring_view_from_ustring(s->src);
                 url_t script_url = url_parse(src_view);
                 if (script_url.valid) {
-                    net_download_async(script_url, on_html_script_download);
+                    net_download_async(script_url, on_html_script_download, NULL);
                 }
                 ustring_free(&s->src);
             } else if (s->code.length > 0) {
@@ -329,7 +467,7 @@ int script_eval_uri(ustring_view uri) {
             LOG_WARN("script.v8", "invalid url");
             return -1;
         }
-        net_download_async(url, on_remote_script_download);
+        net_download_async(url, on_remote_script_download, NULL);
     } else {
         ustring content = io_read_file(os_get_bundle_path(ustring_view_to_ustring(&uri)));
         if (content.length == 0) {

--- a/src/script/script.v8.cpp
+++ b/src/script/script.v8.cpp
@@ -18,6 +18,7 @@
 #include "foundation/global.h"
 #include "foundation/ustring.h"
 #include "foundation/network.h"
+#include "foundation/html_parser.h"
 #include "foundation/logger.h"
 #include "foundation/io.h"
 #include "ui/ui_dev_tool.h"
@@ -279,10 +280,43 @@ int script_eval_direct(ustring source, ustring *result) {
     return 0;
 }
 
-static void on_remote_script_download(net_request_t request, net_response_t response) {
-    LOG_INFO("script.v8", "remote script downloaded");
+static void on_html_script_download(net_request_t request, net_response_t response) {
+    LOG_INFO("script.v8", "html script downloaded");
     g_ctx.invalid_script =
         script_eval(ustring_view_to_ustring(&response.body), request.url.url) != 0;
+
+    os_window_t *window = g_ctx.window;
+    os_window_on_resize(window, window->width, window->height);
+}
+
+static void on_remote_script_download(net_request_t request, net_response_t response) {
+    LOG_INFO("script.v8", "remote content downloaded");
+
+    const char *body_data = response.body.base.data + response.body.start;
+    u32 body_len = response.body.length;
+
+    if (html_is_html(body_data, body_len)) {
+        LOG_INFO("script.v8", "detected HTML page, extracting scripts");
+        html_parse_result_t parsed = html_parse_scripts(body_data, body_len, request.url);
+        for (u32 i = 0; i < parsed.count; i++) {
+            html_script_t *s = &parsed.scripts[i];
+            if (s->src.length > 0) {
+                ustring_view src_view = ustring_view_from_ustring(s->src);
+                url_t script_url = url_parse(src_view);
+                if (script_url.valid) {
+                    net_download_async(script_url, on_html_script_download);
+                }
+                ustring_free(&s->src);
+            } else if (s->code.length > 0) {
+                ustring_view filename = ustring_view_STR("<inline>");
+                g_ctx.invalid_script = script_eval(s->code, filename) != 0;
+                ustring_free(&s->code);
+            }
+        }
+    } else {
+        g_ctx.invalid_script =
+            script_eval(ustring_view_to_ustring(&response.body), request.url.url) != 0;
+    }
 
     os_window_t *window = g_ctx.window;
     os_window_on_resize(window, window->width, window->height);


### PR DESCRIPTION
When a user enters a web URL, detect if the response is HTML, parse
<script src="..."> and inline <script> tags, resolve relative URLs
against the base URL, then download and run the referenced JS files.

- src/foundation/html_parser.h/c: new html_is_html(), html_parse_scripts(),
  html_resolve_url() (handles absolute, root-relative, relative paths)
- script.qjs.c, script.v8.cpp: on_remote_script_download now branches on
  HTML vs JS content; HTML triggers per-script net_download_async calls

https://claude.ai/code/session_01P4v8nWH6FZmKJ8dix62SLL